### PR TITLE
Set default debian install_opts to accommodate upgrades.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@ when 'rhel'
   default['repose']['repo']['gpgcheck'] = false # the openrepose repo doesn't sign packages
   default['repose']['repo']['enabled'] = true
   default['repose']['repo']['managed'] = true
-  default['repose']['install_opts'] = ''
+  default['repose']['install_opts'] = '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"' # default apt config will block upgrades
 when 'debian'
   default['repose']['owner'] = 'root'
   default['repose']['group'] = 'root'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cit-ops@rackspace.com"
 license          "All rights reserved"
 description      "Installs/Configures repose"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.1"
+version          "2.0.2"
 
 depends          "apt"
 depends          "yum", '~> 3.0'


### PR DESCRIPTION
Without setting this, the cookbook as-is wont accommodate upgrades.
Default behavior of dpkg is to prompt when new package files will
clobber existing package files which have seen changes.  While apt
can have a global setting tuned to reflect similar install options,
this just assumes that you want to get to the declared version no
matter what state you might be in previously.
