### PR TITLE
Allow for connection pool filter to be more attribute driven.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,17 @@ The limit groups array defaults to:
 
 ## connection-pool attributes
 
+* `node['repose']['connection_pool']['chunked_encoding']` - Use the default unless your programming language does not support chunked encoding. Some Repose filters modify request bodies. Due to this possibility Repose will, by default, send requests with entities as chunked. Setting chunked-encoding to false will cause Repose to attempt to evaluate the actual content length of the request by reading the ServletInputStream. Default is true.
 * `node['repose']['connection_pool']['max_total']` - Maximum number of connections that Repose opens across all endpoints. (If set too high, you might run out of memory.) Default is 400.
 * `node['repose']['connection_pool']['max_per_route']` - Maximum number of connections that Repose opens per endpoint. Default is 200.
 * `node['repose']['connection_pool']['socket_timeout']` - Number of milliseconds a request is in flight before it times out. Default is 30000.
 * `node['repose']['connection_pool']['connection_timeout']` - Number of milliseconds a connection waits to send a request. Default is 30000.
+* `node['repose']['connection_pool']['socket_buffer_size']` - Default is 8192.
+* `node['repose']['connection_pool']['connection_max_line_length']` - Default is 8192.
+* `node['repose']['connection_pool']['connection_max_header_count']` - Maximum number of headers that can be sent in the request. Default is 100.
+* `node['repose']['connection_pool']['connection_max_status_line_garbage']` - Maximum number of lines allotted for garbage. Default is 100.
+* `node['repose']['connection_pool']['tcp_nodelay']` - Default is true.
+* `node['repose']['connection_pool']['keepalive_timeout']` - If a Keep-Alive header is not present in the response, the value of keepalive.timeout is evaluated. If this value is 0, the connection will be kept alive indefinitely. If the value is greater than 0, the connection will be kept alive for the number of milliseconds specified. Set to 1 to connect:close. Default is 0.
 
 # Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -112,7 +112,14 @@ default['repose']['rate_limiting']['limit_groups'] = [
   }
 ]
 
+default['repose']['connection_pool']['chunked_encoding'] = true
 default['repose']['connection_pool']['max_total'] = 400
 default['repose']['connection_pool']['max_per_route'] = 200
 default['repose']['connection_pool']['socket_timeout'] = 30000
 default['repose']['connection_pool']['connection_timeout'] = 30000
+default['repose']['connection_pool']['socket_buffer_size'] = 8192
+default['repose']['connection_pool']['connection_max_line_length'] = 8192
+default['repose']['connection_pool']['connection_max_header_count'] = 100
+default['repose']['connection_pool']['connection_max_status_line_garbage'] = 100
+default['repose']['connection_pool']['tcp_nodelay'] = true
+default['repose']['connection_pool']['keepalive_timeout'] = 0

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cit-ops@rackspace.com"
 license          "All rights reserved"
 description      "Installs/Configures repose"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.2"
+version          "2.1.0"
 
 depends          "apt"
 depends          "yum", '~> 3.0'

--- a/recipes/service-connection-pool.rb
+++ b/recipes/service-connection-pool.rb
@@ -10,10 +10,17 @@ template "#{node['repose']['config_directory']}/http-connection-pool.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
+    :chunked_encoding => node['repose']['connection_pool']['chunked_encoding'],
     :max_total => node['repose']['connection_pool']['max_total'],
     :max_per_route => node['repose']['connection_pool']['max_per_route'],
     :socket_timeout => node['repose']['connection_pool']['socket_timeout'],
     :connection_timeout => node['repose']['connection_pool']['connection_timeout']
+    :socket_buffer_size=> node['repose']['connection_pool']['socket_buffer_size']
+    :connection_max_line_length=> node['repose']['connection_pool']['connection_max_line_length']
+    :connection_max_header_count=> node['repose']['connection_pool']['connection_max_header_count']
+    :connection_max_status_line_garbage=> node['repose']['connection_pool']['connection_max_status_line_garbage']
+    :tcp_nodelay=> node['repose']['connection_pool']['tcp_nodelay']
+    :keepalive_timeout=> node['repose']['connection_pool']['keepalive_timeout']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/templates/default/http-connection-pool.cfg.xml.erb
+++ b/templates/default/http-connection-pool.cfg.xml.erb
@@ -5,16 +5,16 @@
     -->
     <pool id="default"
           default="true"
-          chunked-encoding="true"
+          chunked-encoding="<%= @chunked_encoding %>"
           http.conn-manager.max-total="<%= @max_total %>"
           http.conn-manager.max-per-route="<%= @max_per_route %>"
           http.socket.timeout="<%= @socket_timeout %>"
-          http.socket.buffer-size="8192"
-          http.connection.timeout="<%=@connection_timeout %>"
-          http.connection.max-line-length="8192"
-          http.connection.max-header-count="100"
-          http.connection.max-status-line-garbage="100"
-          http.tcp.nodelay="true"
-          keepalive.timeout="0"/>
+          http.socket.buffer-size="<%= @socket_buffer_size %>"
+          http.connection.timeout="<%= @connection_timeout %>"
+          http.connection.max-line-length="<%= @connection_max_line_length %>"
+          http.connection.max-header-count="<%= @connection_max_header_count %>"
+          http.connection.max-status-line-garbage="<%= @connection_max_status_line_garbage %>"
+          http.tcp.nodelay="<%= @tcp_nodelay %>"
+          keepalive.timeout="<%= keepalive_timeout %>"/>
 
 </http-connection-pools>


### PR DESCRIPTION
The Solum project needs the encoding to not be chunked when proxying
to the origin server.  This change allows that to be tunable, along
with other attributes.
