### PR TITLE
Add apt to default test-kitchen run_list.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,7 @@ platforms:
 suites:
 - name: default
   run_list: [
+    "apt",
     "java",
     "recipe[repose::filter-slf4j-http-logging]",
     "recipe[repose::filter-ip-identity]",

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cit-ops@rackspace.com"
 license          "All rights reserved"
 description      "Installs/Configures repose"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.2.3"
+version          "2.3.3"
 
 depends          "apt"
 depends          "yum", '~> 3.0'


### PR DESCRIPTION
Debuntu needs an up-to-date apt-cache to converge.

Passes just fine on CentOS runs.
