### PR TITLE
Renamed client authz template to openstack-authz

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cit-ops@rackspace.com"
 license          "All rights reserved"
 description      "Installs/Configures repose"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.11.0"
+version          "2.11.1"
 
 depends          "apt"
 depends          "yum", '~> 3.0'

--- a/recipes/filter-client-authorization.rb
+++ b/recipes/filter-client-authorization.rb
@@ -12,7 +12,7 @@ unless node['repose']['filters'].include? 'client-authorization'
   node.normal['repose']['filters'] = filters
 end
 
-template "#{node['repose']['config_directory']}/client-authorization.cfg.xml" do
+template "#{node['repose']['config_directory']}/openstack-authorization.cfg.xml" do
   owner node['repose']['owner']
   group node['repose']['group']
   mode '0644'

--- a/templates/default/openstack-authorization.cfg.xml.erb
+++ b/templates/default/openstack-authorization.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<rackspace-authorization xmlns='http://docs.openrepose.org/repose/openstack-identity/auth-z/v1.0'>
+<rackspace-authorization xmlns="http://openrepose.org/components/openstack-identity/auth-z/v1.0">
     <authentication-server
         username="<%= @username %>"
         password="<%= @password %>"


### PR DESCRIPTION
This is the default location for the client authz filter.