### PR TITLE
Add repose-extensions-filter-bundle

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cit-ops@rackspace.com"
 license          "All rights reserved"
 description      "Installs/Configures repose"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.11.1"
+version          "2.11.2"
 
 depends          "apt"
 depends          "yum", '~> 3.0'

--- a/recipes/install_debian.rb
+++ b/recipes/install_debian.rb
@@ -17,6 +17,7 @@ end
 
 %w{ repose-valve
     repose-filter-bundle
+    repose-extensions-filter-bundle
 }.each do |p|
   package p do
     options node['repose']['install_opts']

--- a/recipes/install_rhel.rb
+++ b/recipes/install_rhel.rb
@@ -18,6 +18,7 @@ end
 
 %w{ repose-valve
     repose-filter-bundle
+    repose-extensions-filter-bundle
 }.each do |p|
   package p do
     options node['repose']['install_opts']


### PR DESCRIPTION
Repose broke up their packages a bit based on some internal criteria.  This resolves that.