### PR TITLE
Fix the 'Fix rubocop warnings'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,20 @@
+Metrics/AbcSize:
+  Max: 23
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FileName:
+  Enabled: false
+
+Style/UnlessElse:
+  Enabled: false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,25 +1,25 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.configure("2") do |config|
+Vagrant.configure('2') do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  config.vm.hostname = "repose-berkshelf"
+  config.vm.hostname = 'repose-berkshelf'
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "Opscode-CentOS-6.4-x86_64"
+  config.vm.box = 'Opscode-CentOS-6.4-x86_64'
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box"
+  config.vm.box_url = 'https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box'
 
   # Assign this VM to a host-only network IP, allowing you to access it
   # via the IP. Host-only networks can talk to the host machine as well as
   # any other machines on the same network, but cannot be accessed (through this
   # network interface) by any external networks.
-  config.vm.network :private_network, ip: "33.33.33.10"
+  config.vm.network :private_network, ip: '33.33.33.10'
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -73,10 +73,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :chef_solo do |chef|
     chef.json = {
     }
-    chef.add_recipe("recipe[repose::filter-ip-identity]")
-    chef.add_recipe("recipe[repose::filter-client-auth]")
-    chef.add_recipe("recipe[repose::service-dist-datastore]")
-    chef.add_recipe("recipe[repose]")
-    chef.add_recipe("recipe[minitest-handler]")
+    chef.add_recipe('recipe[repose::filter-ip-identity]')
+    chef.add_recipe('recipe[repose::filter-client-auth]')
+    chef.add_recipe('recipe[repose::service-dist-datastore]')
+    chef.add_recipe('recipe[repose]')
+    chef.add_recipe('recipe[minitest-handler]')
   end
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,7 +42,7 @@ default['repose']['peers'] = [
   { 'cluster_id' => 'repose',
     'id' => 'repose_node1',
     'hostname' => 'localhost',
-    'port' => 8080,
+    'port' => 8080
   }
 ]
 
@@ -56,7 +56,7 @@ default['repose']['endpoints'] = [
     'hostname' => 'openrepose.org',
     'port' => 80,
     'root_path' => '/',
-    'default' => true,
+    'default' => true
   }
 ]
 
@@ -88,7 +88,7 @@ default['repose']['header_normalization']['cluster_id'] = ['all']
 default['repose']['header_normalization']['whitelist'] = [
   { 'id' => 'credentials',
     'uri_regex' => '/servers/(.*)',
-    'headers'   => ['X-Auth-Key','X-Auth-User']
+    'headers'   => ['X-Auth-Key', 'X-Auth-User']
   },
   { 'id' => 'modification',
     'uri_regex' => '/resource/(.*)',
@@ -98,7 +98,7 @@ default['repose']['header_normalization']['whitelist'] = [
 ]
 default['repose']['header_normalization']['blacklist'] = [
   { 'id' => 'rate-limit-headers',
-    'headers'   => ['X-PP-User','X-PP-Groups']
+    'headers'   => ['X-PP-User', 'X-PP-Groups']
   }
 ]
 

--- a/files/default/test/client-authentication.rb
+++ b/files/default/test/client-authentication.rb
@@ -1,14 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-client-authentication' do
-
   it 'sets up client-authorization.cfg.xml' do
     file('/etc/repose/client-authorization.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end
-
-

--- a/files/default/test/default_test.rb
+++ b/files/default/test/default_test.rb
@@ -1,7 +1,6 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::default' do
-
   it 'starts the repose-valve service' do
     service('repose-valve').must_be_enabled
     service('repose-valve').must_be_running
@@ -10,23 +9,21 @@ describe_recipe 'repose::default' do
   it 'sets up container.cfg.xml' do
     file('/etc/repose/container.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
 
   it 'sets up system-model.cfg.xml' do
     file('/etc/repose/system-model.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
 
   it 'sets up log4j.properties' do
     file('/etc/repose/log4j.properties').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end
-

--- a/files/default/test/filter-api-validator.rb
+++ b/files/default/test/filter-api-validator.rb
@@ -1,13 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-api-validator' do
-
   it 'sets up validator.cfg.xml' do
     file('/etc/repose/validator.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end
-

--- a/files/default/test/filter-client-auth_test.rb
+++ b/files/default/test/filter-client-auth_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-client-auth' do
-
   it 'sets up client-auth-n.cfg.xml' do
     file('/etc/repose/client-auth-n.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/filter-header-identity_test.rb
+++ b/files/default/test/filter-header-identity_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-header-identity' do
-
   it 'sets up header-identity.cfg.xml' do
     file('/etc/repose/header-identity.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/filter-header-translation_test.rb
+++ b/files/default/test/filter-header-translation_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-header-translation' do
-
   it 'sets up header-translation.cfg.xml' do
     file('/etc/repose/header-translation.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/filter-ip-identity_test.rb
+++ b/files/default/test/filter-ip-identity_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-ip-identity' do
-
   it 'sets up ip-identity.cfg.xml' do
     file('/etc/repose/ip-identity.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/filter-rackspace-auth-user_test.rb
+++ b/files/default/test/filter-rackspace-auth-user_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-rackspace-auth-user' do
-
   it 'sets up rackspace-auth-user.cfg.xml' do
     file('/etc/repose/rackspace-auth-user.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/filter-rate-limiting_test.rb
+++ b/files/default/test/filter-rate-limiting_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-rate-limiting' do
-
   it 'sets up rate-limiting.cfg.xml' do
     file('/etc/repose/rate-limiting.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/filter-slf4j-http-logging_test.rb
+++ b/files/default/test/filter-slf4j-http-logging_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-slf4j-http-logging' do
-
   it 'sets up slf4j-http-logging.cfg.xml' do
     file('/etc/repose/slf4j-http-logging.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/filter-translation_test.rb
+++ b/files/default/test/filter-translation_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-translation' do
-
   it 'sets up translation.cfg.xml' do
     file('/etc/repose/translation.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/filter-uri-identity_test.rb
+++ b/files/default/test/filter-uri-identity_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-uri-identity' do
-
   it 'sets up uri-identity.cfg.xml' do
     file('/etc/repose/uri-identity.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/install_debian_test.rb
+++ b/files/default/test/install_debian_test.rb
@@ -1,10 +1,8 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::install_debian' do
-
   it 'installs Repose' do
     package('repose-valve').must_be_installed
     package('repose-filter-bundle').must_be_installed
   end
-
 end

--- a/files/default/test/install_rhel_test.rb
+++ b/files/default/test/install_rhel_test.rb
@@ -1,10 +1,8 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::install_rhel' do
-
   it 'installs Repose' do
     package('repose-valve').must_be_installed
     package('repose-filter-bundle').must_be_installed
   end
-
 end

--- a/files/default/test/service-connection-pool_test.rb
+++ b/files/default/test/service-connection-pool_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-connection-pool' do
-
   it 'sets up http-connection-pool.cfg.xml' do
     file('/etc/repose/http-connection-pool.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/files/default/test/service-dist-datastore_test.rb
+++ b/files/default/test/service-dist-datastore_test.rb
@@ -1,12 +1,10 @@
 require 'minitest/spec'
 
 describe_recipe 'repose::filter-dist-datastore' do
-
   it 'sets up dist-datastore.cfg.xml' do
     file('/etc/repose/dist-datastore.cfg.xml').must_exist.with(
       :owner, node['repose']['owner']).and(
-      :group, node['repose']['group']).and(
-      :mode, '0644')
+        :group, node['repose']['group']).and(
+          :mode, '0644')
   end
-
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,15 +2,14 @@ class Chef
   module RackHelpers
     module Repose
       class << self
-
         def peers(nodes)
           nodes = [nodes] if nodes.class == Chef::Node
-          nodes.map{ |node| node_to_peer(node) }
+          nodes.map { |node| node_to_peer(node) }
         end
 
         def node_to_peer(node)
           unless node['repose']['cluster_id'].nil?
-            cluster_ids = [ node['repose']['cluster_id'] ]
+            cluster_ids = [node['repose']['cluster_id']]
           else
             cluster_ids = node['repose']['cluster_ids']
           end
@@ -25,7 +24,6 @@ class Chef
             }
           end
         end
-
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,11 +1,11 @@
-name             "repose"
-maintainer       "Rackspace Hosting"
-maintainer_email "cit-ops@rackspace.com"
-license          "All rights reserved"
-description      "Installs/Configures repose"
+name 'repose'
+maintainer 'Rackspace Hosting'
+maintainer_email 'cit-ops@rackspace.com'
+license 'All rights reserved'
+description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.11.4"
+version '2.11.4'
 
-depends          "apt"
-depends          "yum", '~> 3.0'
-depends          "yum-epel"
+depends 'apt'
+depends 'yum', '~> 3.0'
+depends 'yum-epel'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,7 +8,7 @@
 include_recipe 'repose::install'
 
 service 'repose-valve' do
-  supports :restart => true, :status => true
+  supports restart: true, status: true
   action [:enable, :start]
 end
 
@@ -16,7 +16,7 @@ include_recipe 'repose::load_peers' if node['repose']['peer_search_enabled']
 
 unless node['repose']['cluster_id'].nil?
   log "Please note that node['repose']['cluster_id'] is deprecated. We've set node['repose']['cluster_ids'] to [#{node['repose']['cluster_id']}] in an effort to maintain compatability with earlier versions. This functionality will be removed in a future version."
-  node.normal['repose']['cluster_ids'] = [ node['repose']['cluster_id'] ]
+  node.normal['repose']['cluster_ids'] = [node['repose']['cluster_id']]
 end
 
 directory "#{node['repose']['config_directory']}" do
@@ -27,26 +27,26 @@ end
 
 services = node['repose']['services'].reject { |x| x == 'connection-pool' }
 service_cluster_map = {
-  'dist-datastore' => node['repose']['dist_datastore' ]['cluster_id']
+  'dist-datastore' => node['repose']['dist_datastore']['cluster_id']
 }
 
 filters = node['repose']['filters']
 filter_cluster_map = {
-  'api-validator'         => node['repose']['api_validator'        ]['cluster_id'],
-  'client-auth'           => node['repose']['client_auth'          ]['cluster_id'],
-  'client-authorization'  => node['repose']['client_authorization' ]['cluster_id'],
+  'api-validator'         => node['repose']['api_validator']['cluster_id'],
+  'client-auth'           => node['repose']['client_auth']['cluster_id'],
+  'client-authorization'  => node['repose']['client_authorization']['cluster_id'],
   'content-type-stripper' => node['repose']['content_type_stripper']['cluster_id'],
-  'derp'                  => node['repose']['derp'                 ]['cluster_id'],
-  'header-identity'       => node['repose']['header_identity'      ]['cluster_id'],
-  'header-normalization'  => node['repose']['header_normalization' ]['cluster_id'],
-  'header-translation'    => node['repose']['header_translation'   ]['cluster_id'],
-  'ip-identity'           => node['repose']['ip_identity'          ]['cluster_id'],
-  'rackspace-auth-user'   => node['repose']['rackspace_auth_user'  ]['cluster_id'],
-  'rate-limiting'         => node['repose']['rate_limiting'        ]['cluster_id'],
-  'slf4j-http-logging'    => node['repose']['slf4j_http_logging'   ]['cluster_id'],
-  'translation'           => node['repose']['translation'          ]['cluster_id'],
-  'uri-identity'          => node['repose']['uri_identity'         ]['cluster_id'],
-  'uri-stripper'          => node['repose']['uri_stripper'         ]['cluster_id']
+  'derp'                  => node['repose']['derp']['cluster_id'],
+  'header-identity'       => node['repose']['header_identity']['cluster_id'],
+  'header-normalization'  => node['repose']['header_normalization']['cluster_id'],
+  'header-translation'    => node['repose']['header_translation']['cluster_id'],
+  'ip-identity'           => node['repose']['ip_identity']['cluster_id'],
+  'rackspace-auth-user'   => node['repose']['rackspace_auth_user']['cluster_id'],
+  'rate-limiting'         => node['repose']['rate_limiting']['cluster_id'],
+  'slf4j-http-logging'    => node['repose']['slf4j_http_logging']['cluster_id'],
+  'translation'           => node['repose']['translation']['cluster_id'],
+  'uri-identity'          => node['repose']['uri_identity']['cluster_id'],
+  'uri-stripper'          => node['repose']['uri_stripper']['cluster_id']
 }
 
 template "#{node['repose']['config_directory']}/system-model.cfg.xml" do

--- a/recipes/filter-api-validator.rb
+++ b/recipes/filter-api-validator.rb
@@ -17,9 +17,9 @@ template "#{node['repose']['config_directory']}/validator.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :wadl => node['repose']['api_validator']['wadl'],
-    :dot_output => node['repose']['api_validator']['dot_output'],
-    :enable_rax_roles => node['repose']['api_validator']['enable_rax_roles'],
+    wadl: node['repose']['api_validator']['wadl'],
+    dot_output: node['repose']['api_validator']['dot_output'],
+    enable_rax_roles: node['repose']['api_validator']['enable_rax_roles']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-client-auth.rb
+++ b/recipes/filter-client-auth.rb
@@ -17,22 +17,22 @@ template "#{node['repose']['config_directory']}/client-auth-n.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :auth_provider => node['repose']['client_auth']['auth_provider'],
-    :username => node['repose']['client_auth']['username_admin'],
-    :password => node['repose']['client_auth']['password_admin'],
-    :auth_uri => node['repose']['client_auth']['auth_uri'],
-    :mapping_regex => node['repose']['client_auth']['mapping_regex'],
-    :mapping_type => node['repose']['client_auth']['mapping_type'],
-    :tenant_id => node['repose']['client_auth']['tenant_id'],
-    :delegable => node['repose']['client_auth']['delegable'],
-    :tenanted => node['repose']['client_auth']['tenanted'],
-    :request_groups => node['repose']['client_auth']['request_groups'],
-    :token_cache_timeout => node['repose']['client_auth']['token_cache_timeout'],
-    :group_cache_timeout => node['repose']['client_auth']['group_cache_timeout'],
-    :ignore_tenant_roles => node['repose']['client_auth']['ignore_tenant_roles'],
-    :endpoints_in_header => node['repose']['client_auth']['endpoints_in_header'],
-    :white_list => node['repose']['client_auth']['white_list'],
-    :uri_regex => node['repose']['client_auth']['uri_regex']
+    auth_provider: node['repose']['client_auth']['auth_provider'],
+    username: node['repose']['client_auth']['username_admin'],
+    password: node['repose']['client_auth']['password_admin'],
+    auth_uri: node['repose']['client_auth']['auth_uri'],
+    mapping_regex: node['repose']['client_auth']['mapping_regex'],
+    mapping_type: node['repose']['client_auth']['mapping_type'],
+    tenant_id: node['repose']['client_auth']['tenant_id'],
+    delegable: node['repose']['client_auth']['delegable'],
+    tenanted: node['repose']['client_auth']['tenanted'],
+    request_groups: node['repose']['client_auth']['request_groups'],
+    token_cache_timeout: node['repose']['client_auth']['token_cache_timeout'],
+    group_cache_timeout: node['repose']['client_auth']['group_cache_timeout'],
+    ignore_tenant_roles: node['repose']['client_auth']['ignore_tenant_roles'],
+    endpoints_in_header: node['repose']['client_auth']['endpoints_in_header'],
+    white_list: node['repose']['client_auth']['white_list'],
+    uri_regex: node['repose']['client_auth']['uri_regex']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-client-authorization.rb
+++ b/recipes/filter-client-authorization.rb
@@ -17,19 +17,19 @@ template "#{node['repose']['config_directory']}/openstack-authorization.cfg.xml"
   group node['repose']['group']
   mode '0644'
   variables(
-    :username => node['repose']['client_authorization']['username_admin'],
-    :password => node['repose']['client_authorization']['password_admin'],
-    :auth_uri => node['repose']['client_authorization']['auth_uri'],
-    :tenant_id_admin => node['repose']['client_authorization']['tenant_id_admin'],
-    :endpoint_list_ttl => node['repose']['client_authorization']['endpoint_list_ttl'],
-    :connection_pool_id => node['repose']['client_authorization']['connection_pool_id'],
-    :service_endpoint => node['repose']['client_authorization']['service_endpoint'],
-    :service_region => node['repose']['client_authorization']['service_region'],
-    :service_name => node['repose']['client_authorization']['service_name'],
-    :service_type => node['repose']['client_authorization']['service_type'],
-    :ignore_tenant_roles => node['repose']['client_authorization']['ignore_tenant_roles'],
-    :roles => node['repose']['client_authorization']['roles'],
-    :delegating_quality => node['repose']['client_authorization']['delegating_quality'],
+    username: node['repose']['client_authorization']['username_admin'],
+    password: node['repose']['client_authorization']['password_admin'],
+    auth_uri: node['repose']['client_authorization']['auth_uri'],
+    tenant_id_admin: node['repose']['client_authorization']['tenant_id_admin'],
+    endpoint_list_ttl: node['repose']['client_authorization']['endpoint_list_ttl'],
+    connection_pool_id: node['repose']['client_authorization']['connection_pool_id'],
+    service_endpoint: node['repose']['client_authorization']['service_endpoint'],
+    service_region: node['repose']['client_authorization']['service_region'],
+    service_name: node['repose']['client_authorization']['service_name'],
+    service_type: node['repose']['client_authorization']['service_type'],
+    ignore_tenant_roles: node['repose']['client_authorization']['ignore_tenant_roles'],
+    roles: node['repose']['client_authorization']['roles'],
+    delegating_quality: node['repose']['client_authorization']['delegating_quality']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-content-type-stripper.rb
+++ b/recipes/filter-content-type-stripper.rb
@@ -13,5 +13,3 @@ unless node['repose']['filters'].include? 'content-type-stripper'
 end
 
 # No configuration template required - content-type-stripper doesn't have a config
-
-

--- a/recipes/filter-derp.rb
+++ b/recipes/filter-derp.rb
@@ -13,5 +13,3 @@ unless node['repose']['filters'].include? 'derp'
 end
 
 # No configuration template required - derp doesn't have a config
-
-

--- a/recipes/filter-header-identity.rb
+++ b/recipes/filter-header-identity.rb
@@ -17,7 +17,7 @@ template "#{node['repose']['config_directory']}/header-identity.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :headers => node['repose']['header_identity']['headers']
+    headers: node['repose']['header_identity']['headers']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-header-normalization.rb
+++ b/recipes/filter-header-normalization.rb
@@ -17,8 +17,8 @@ template "#{node['repose']['config_directory']}/header-normalization.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :whitelist => node['repose']['header_normalization']['whitelist'],
-    :blacklist => node['repose']['header_normalization']['blacklist']
+    whitelist: node['repose']['header_normalization']['whitelist'],
+    blacklist: node['repose']['header_normalization']['blacklist']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-header-translation.rb
+++ b/recipes/filter-header-translation.rb
@@ -17,7 +17,7 @@ template "#{node['repose']['config_directory']}/header-translation.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :headers => node['repose']['header_translation']['headers']
+    headers: node['repose']['header_translation']['headers']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-ip-identity.rb
+++ b/recipes/filter-ip-identity.rb
@@ -17,11 +17,9 @@ template "#{node['repose']['config_directory']}/ip-identity.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :quality => node['repose']['ip_identity']['quality'],
-    :white_list_quality => node['repose']['ip_identity']['white_list_quality'],
-    :white_list_ip_addresses => node['repose']['ip_identity']['white_list_ip_addresses']
+    quality: node['repose']['ip_identity']['quality'],
+    white_list_quality: node['repose']['ip_identity']['white_list_quality'],
+    white_list_ip_addresses: node['repose']['ip_identity']['white_list_ip_addresses']
   )
   notifies :restart, 'service[repose-valve]'
 end
-
-

--- a/recipes/filter-rackspace-auth-user.rb
+++ b/recipes/filter-rackspace-auth-user.rb
@@ -17,9 +17,8 @@ template "#{node['repose']['config_directory']}/rackspace-auth-user.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :v1_1 => node['repose']['rackspace_auth_user']['v1_1'],
-    :v2_0 => node['repose']['rackspace_auth_user']['v2_0']
+    v1_1: node['repose']['rackspace_auth_user']['v1_1'],
+    v2_0: node['repose']['rackspace_auth_user']['v2_0']
   )
   notifies :restart, 'service[repose-valve]'
 end
-

--- a/recipes/filter-rate-limiting.rb
+++ b/recipes/filter-rate-limiting.rb
@@ -17,11 +17,9 @@ template "#{node['repose']['config_directory']}/rate-limiting.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :uri_regex => node['repose']['rate_limiting']['uri_regex'],
-    :include_absolute_limits => node['repose']['rate_limiting']['include_absolute_limits'],
-    :limit_groups => node['repose']['rate_limiting']['limit_groups']
+    uri_regex: node['repose']['rate_limiting']['uri_regex'],
+    include_absolute_limits: node['repose']['rate_limiting']['include_absolute_limits'],
+    limit_groups: node['repose']['rate_limiting']['limit_groups']
   )
   notifies :restart, 'service[repose-valve]'
 end
-
-

--- a/recipes/filter-slf4j-http-logging.rb
+++ b/recipes/filter-slf4j-http-logging.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: repose
-# Recipe:: filter-slf4j-http-logging 
+# Recipe:: filter-slf4j-http-logging
 #
 # Copyright (C) 2013 Rackspace Hosting
 #
@@ -17,8 +17,8 @@ template "#{node['repose']['config_directory']}/slf4j-http-logging.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :id => node['repose']['slf4j_http_logging']['id'],
-    :format => node['repose']['slf4j_http_logging']['format'],
+    id: node['repose']['slf4j_http_logging']['id'],
+    format: node['repose']['slf4j_http_logging']['format']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-translation.rb
+++ b/recipes/filter-translation.rb
@@ -17,9 +17,9 @@ template "#{node['repose']['config_directory']}/translation.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :allow_doctype_decl => node['repose']['translation']['allow_doctype_decl'],
-    :request_translations => node['repose']['translation']['request_translations'],
-    :response_translations => node['repose']['translation']['response_translations']
+    allow_doctype_decl: node['repose']['translation']['allow_doctype_decl'],
+    request_translations: node['repose']['translation']['request_translations'],
+    response_translations: node['repose']['translation']['response_translations']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-uri-identity.rb
+++ b/recipes/filter-uri-identity.rb
@@ -17,11 +17,9 @@ template "#{node['repose']['config_directory']}/uri-identity.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :mappings => node['repose']['uri_identity']['mappings'],
-    :group => node['repose']['uri_identity']['group'],
-    :quality => node['repose']['uri_identity']['quality']
+    mappings: node['repose']['uri_identity']['mappings'],
+    group: node['repose']['uri_identity']['group'],
+    quality: node['repose']['uri_identity']['quality']
   )
   notifies :restart, 'service[repose-valve]'
 end
-
-

--- a/recipes/filter-uri-stripper.rb
+++ b/recipes/filter-uri-stripper.rb
@@ -17,8 +17,8 @@ template "#{node['repose']['config_directory']}/uri-stripper.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :rewrite_location => node['repose']['uri_stripper']['rewrite_location'],
-    :token_index => node['repose']['uri_stripper']['token_index']
+    rewrite_location: node['repose']['uri_stripper']['rewrite_location'],
+    token_index: node['repose']['uri_stripper']['token_index']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/install_debian.rb
+++ b/recipes/install_debian.rb
@@ -15,10 +15,10 @@ apt_repository 'openrepose' do
   only_if { node['repose']['repo']['managed'] }
 end
 
-%w{ repose-valve
-    repose-filter-bundle
-    repose-extensions-filter-bundle
-}.each do |p|
+%w(repose-valve
+   repose-filter-bundle
+   repose-extensions-filter-bundle
+).each do |p|
   package p do
     options node['repose']['install_opts']
     version node['repose']['version']

--- a/recipes/install_rhel.rb
+++ b/recipes/install_rhel.rb
@@ -16,10 +16,10 @@ yum_repository 'openrepose' do
   only_if { node['repose']['repo']['managed'] }
 end
 
-%w{ repose-valve
-    repose-filter-bundle
-    repose-extensions-filter-bundle
-}.each do |p|
+%w(repose-valve
+   repose-filter-bundle
+   repose-extensions-filter-bundle
+).each do |p|
   package p do
     options node['repose']['install_opts']
     version node['repose']['version']

--- a/recipes/load_peers.rb
+++ b/recipes/load_peers.rb
@@ -19,7 +19,7 @@ if node['repose']['peer_search_enabled']
 
   peers = RackHelpers::Repose.peers found_nodes
   peers.flatten!
-  peers.sort!{ |a,b| a['id'] <=> b['id'] }
+  peers.sort! { |a, b| a['id'] <=> b['id'] }
 
   node.normal['repose']['peers'] = peers
 

--- a/recipes/service-connection-pool.rb
+++ b/recipes/service-connection-pool.rb
@@ -10,17 +10,17 @@ template "#{node['repose']['config_directory']}/http-connection-pool.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :chunked_encoding => node['repose']['connection_pool']['chunked_encoding'],
-    :max_total => node['repose']['connection_pool']['max_total'],
-    :max_per_route => node['repose']['connection_pool']['max_per_route'],
-    :socket_timeout => node['repose']['connection_pool']['socket_timeout'],
-    :connection_timeout => node['repose']['connection_pool']['connection_timeout'],
-    :socket_buffer_size=> node['repose']['connection_pool']['socket_buffer_size'],
-    :connection_max_line_length=> node['repose']['connection_pool']['connection_max_line_length'],
-    :connection_max_header_count=> node['repose']['connection_pool']['connection_max_header_count'],
-    :connection_max_status_line_garbage=> node['repose']['connection_pool']['connection_max_status_line_garbage'],
-    :tcp_nodelay=> node['repose']['connection_pool']['tcp_nodelay'],
-    :keepalive_timeout=> node['repose']['connection_pool']['keepalive_timeout']
+    chunked_encoding: node['repose']['connection_pool']['chunked_encoding'],
+    max_total: node['repose']['connection_pool']['max_total'],
+    max_per_route: node['repose']['connection_pool']['max_per_route'],
+    socket_timeout: node['repose']['connection_pool']['socket_timeout'],
+    connection_timeout: node['repose']['connection_pool']['connection_timeout'],
+    socket_buffer_size: node['repose']['connection_pool']['socket_buffer_size'],
+    connection_max_line_length: node['repose']['connection_pool']['connection_max_line_length'],
+    connection_max_header_count: node['repose']['connection_pool']['connection_max_header_count'],
+    connection_max_status_line_garbage: node['repose']['connection_pool']['connection_max_status_line_garbage'],
+    tcp_nodelay: node['repose']['connection_pool']['tcp_nodelay'],
+    keepalive_timeout: node['repose']['connection_pool']['keepalive_timeout']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/service-dist-datastore.rb
+++ b/recipes/service-dist-datastore.rb
@@ -17,10 +17,10 @@ template "#{node['repose']['config_directory']}/dist-datastore.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :allow_all => node['repose']['dist_datastore']['allow_all'],
-    :allowed_hosts => node['repose']['dist_datastore']['allowed_hosts'],
-    :cluster_ids => node['repose']['cluster_ids'],
-    :port => node['repose']['dist_datastore']['port']
+    allow_all: node['repose']['dist_datastore']['allow_all'],
+    allowed_hosts: node['repose']['dist_datastore']['allowed_hosts'],
+    cluster_ids: node['repose']['cluster_ids'],
+    port: node['repose']['dist_datastore']['port']
   )
   notifies :restart, 'service[repose-valve]'
 end


### PR DESCRIPTION
yo dawg.

This is a sort-of rebase of/connected to #30

The difference is that I used the default `.rubocop.yml` as the rules file path, not `.rubocop_todo.yml`, so running `rubocop` without any flags completes successfully. The rules can be tuned as it makes sense.