### PR TITLE
Adding support for the service-admin-roles element in the client-auth filter

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -130,6 +130,7 @@ default['repose']['client_auth']['tenanted'] = true
 default['repose']['client_auth']['request_groups'] = true
 default['repose']['client_auth']['token_cache_timeout'] = 600000
 default['repose']['client_auth']['group_cache_timeout'] = 600000
+default['repose']['client_auth']['service_admin_roles'] = []
 default['repose']['client_auth']['ignore_tenant_roles'] = []
 default['repose']['client_auth']['endpoints_in_header'] = false
 default['repose']['client_auth']['white_list'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cit-ops@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.12.0'
+version '2.13.0'
 
 depends 'apt'
 depends 'yum', '~> 3.0'

--- a/recipes/filter-client-auth.rb
+++ b/recipes/filter-client-auth.rb
@@ -29,6 +29,7 @@ template "#{node['repose']['config_directory']}/client-auth-n.cfg.xml" do
     request_groups: node['repose']['client_auth']['request_groups'],
     token_cache_timeout: node['repose']['client_auth']['token_cache_timeout'],
     group_cache_timeout: node['repose']['client_auth']['group_cache_timeout'],
+    service_admin_roles: node['repose']['client_auth']['service_admin_roles'],
     ignore_tenant_roles: node['repose']['client_auth']['ignore_tenant_roles'],
     endpoints_in_header: node['repose']['client_auth']['endpoints_in_header'],
     white_list: node['repose']['client_auth']['white_list'],

--- a/templates/default/client-auth-n.cfg.xml.erb
+++ b/templates/default/client-auth-n.cfg.xml.erb
@@ -20,6 +20,13 @@
         <% for @mapping in @mapping_regex %>
         <client-mapping id-regex="<%= @mapping %>"/>
         <% end %>
+        <% unless @service_admin_roles.empty? %>
+        <service-admin-roles>
+        <% for @role in @service_admin_roles %>
+            <role><%= @role %></role>
+        <% end %>
+        </service-admin-roles>
+        <% end %>
         <% unless @ignore_tenant_roles.empty? %>
         <ignore-tenant-roles>
         <% for @role in @ignore_tenant_roles %>


### PR DESCRIPTION
The Repose documentation lists a `client-auth` filter option for allowing administrator tokens to hit resources owned by other tenants without validation: `service-admin-roles`

https://repose.atlassian.net/wiki/display/REPOSE/Client+Authentication+filter#ClientAuthenticationfilter-Tenantedmode

This option is missing from the recipe, and we'd like to use it for Cloud DNS's designate environment.

This change was validated locally with the Cloud DNS team's virtualbox-based test kitchen setup.