### PR TITLE
Add support for Global Rate Limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The Repose endpoints array defaults to:
 * `node['repose']['rate_limiting']['cluster_id']` - An array of cluster IDs that use this filter or `['all']` for all cluster IDs.
 * `node['repose']['rate_limiting']['uri_regex']` - A regular expression (regex) for the URI at which the user can query their limits.
 * `node['repose']['rate_limiting']['include_absolute_limits']` - Enables or disables integration with absolute limits.
+* `node['repose']['rate_limiting']['global_limits']` - An array of global limits.  Defaults to empty thus disabled.
 * `node['repose']['rate_limiting']['limit_groups']` - An array of limit groups.
 
 The limit groups array defaults to:
@@ -197,6 +198,19 @@ The limit groups array defaults to:
     'groups' => 'unlimited',
     'default' => false,
     'limits' => []
+  }
+]
+```
+
+Global limit groups are similarly organized:
+```
+[
+  { 'id' => 'create-server',
+    'uri' => '/server/create',
+    'uri-regex' => '/server/create/?',
+    'method' => 'POST',
+    'value' => 10,
+    'unit' => 'SECOND'
   }
 ]
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -153,6 +153,7 @@ default['repose']['client_authorization']['delegating_quality'] = nil
 
 default['repose']['rate_limiting']['cluster_id'] = ['all']
 default['repose']['rate_limiting']['uri_regex'] = '/limits'
+default['repose']['rate_limiting']['global_limits'] = []
 default['repose']['rate_limiting']['include_absolute_limits'] = false
 default['repose']['rate_limiting']['limit_groups'] = [
   { 'id' => 'limited',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cit-ops@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.13.0'
+version '2.14.0'
 
 depends 'apt'
 depends 'yum', '~> 3.0'

--- a/recipes/filter-rate-limiting.rb
+++ b/recipes/filter-rate-limiting.rb
@@ -18,6 +18,7 @@ template "#{node['repose']['config_directory']}/rate-limiting.cfg.xml" do
   mode '0644'
   variables(
     uri_regex: node['repose']['rate_limiting']['uri_regex'],
+    global_limits: node['repose']['rate_limiting']['global_limits'],
     include_absolute_limits: node['repose']['rate_limiting']['include_absolute_limits'],
     limit_groups: node['repose']['rate_limiting']['limit_groups']
   )

--- a/templates/default/rate-limiting.cfg.xml.erb
+++ b/templates/default/rate-limiting.cfg.xml.erb
@@ -8,6 +8,16 @@
     -->
     <request-endpoint uri-regex="<%= @uri_regex %>" include-absolute-limits="<%= @include_absolute_limits %>"/>
 
+    <% unless @global_limits.empty? %>
+    <global-limit-group>
+      <% @global_limits.each do |global_limit| %>
+      <!-- Limits for <%= global_limit['id'] %> -->
+      <limit id="<%= global_limit['id'] %>" uri="<%= global_limit['uri'] %>" uri-regex="<%= global_limit['uri-regex'] %>" http-methods="<%= global_limit['http-methods'] %>" unit="<%= global_limit['unit'] %>" value="<%= global_limit['value'] %>" />
+
+      <% end %>
+    </global-limit-group>
+    <% end %>
+
     <% @limit_groups.each do |limit_group| %>
     <!-- Limits for <%= limit_group['id'] %> -->
     <limit-group id="<%= limit_group['id'] %>" groups="<%= limit_group['groups'] %>" default="<%= limit_group['default'] %>">


### PR DESCRIPTION
https://repose.atlassian.net/wiki/display/REPOSE/Rate+Limiting+filter#RateLimitingfilter-Globalratelimits

This allows you to optionally turn on Global Rate Limits very similarly
to how it is done for Rate Limit Groups elsewhere in this cookbook,
albeit slightly different due to how Global Rate Limits are implemented
in Repose.

This requires Repose >= 6.1.0.3, but if youre not there yet you have
bigger problems. :trollface: 