### PR TITLE
Initial chefspec unit tests and minor cleanup

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.chef.io"
 
 metadata
 cookbook 'minitest-handler'

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,7 @@
 source "https://supermarket.chef.io"
 
 metadata
-cookbook 'minitest-handler'
+cookbook 'apt', '~> 2.9.2'
 cookbook 'java'
+cookbook 'minitest-handler'
+cookbook 'yum-epel', '~> 0.6.6'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,7 +8,7 @@
 include_recipe 'repose::install'
 
 service 'repose-valve' do
-  supports restart: true, status: true
+  supports :restart => true, :status => true
   action [:enable, :start]
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -5,7 +5,9 @@
 # Copyright (C) 2013 Rackspace Hosting
 #
 
-include_recipe value_for_platform_family(
-  'rhel'   => 'repose::install_rhel',
-  'debian' => 'repose::install_debian'
-)
+case node['platform_family']
+when 'rhel'
+  include_recipe 'repose::install_rhel'
+when 'debian'
+  include_recipe 'repose::install_debian'
+end

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -1,0 +1,27 @@
+require 'chefspec'
+require_relative 'spec_helper'
+
+describe 'repose::default' do
+  before { stub_resources }
+
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  
+  it 'starts repose-valve service' do
+    expect(chef_run).to start_service('repose-valve')
+  end
+  it 'creates a directory /etc/repose' do
+    expect(chef_run).to create_directory('/etc/repose')
+  end
+  it 'creates a template /etc/repose/system-model.cfg.xml' do
+    expect(chef_run).to create_template('/etc/repose/system-model.cfg.xml')
+  end
+  it 'creates a template /etc/repose/log4j.properties' do
+    expect(chef_run).to create_template('/etc/repose/log4j.properties')
+  end
+  it 'creates a template /etc/repose/container.cfg.xml' do
+    expect(chef_run).to create_template('/etc/repose/container.cfg.xml')
+  end
+  it 'creates a template /etc/repose/log4j2.xml' do
+    expect(chef_run).to create_template('/etc/repose/log4j2.xml')
+  end
+end

--- a/test/unit/spec/install_debian_spec.rb
+++ b/test/unit/spec/install_debian_spec.rb
@@ -1,0 +1,21 @@
+require 'chefspec'
+require_relative 'spec_helper'
+
+describe 'repose::install_debian' do
+  let(:chef_run) { ChefSpec::SoloRunner.new( :platform => 'ubuntu', :version => '14.04' ).converge('repose::default',described_recipe) }
+
+  it 'includes the recipe apt::default' do
+    expect(chef_run).to include_recipe('apt::default')
+  end
+
+  it 'install the apt repository' do
+    expect(chef_run).to add_apt_repository('openrepose')
+  end
+  
+  packages = %w(repose-valve repose-filter-bundle repose-extensions-filter-bundle)
+  packages.each do |p|
+    it 'installs package #{p}' do
+      expect(chef_run).to install_package(p)
+    end
+  end
+end

--- a/test/unit/spec/install_rhel_spec.rb
+++ b/test/unit/spec/install_rhel_spec.rb
@@ -1,0 +1,40 @@
+require 'chefspec'
+require_relative 'spec_helper'
+
+describe 'repose::install_rhel' do
+  before { stub_resources }
+  let(:chef_run) { ChefSpec::SoloRunner.new( :platform => 'redhat', :version => '7.0' ).converge('repose::default','repose::install',described_recipe) }
+  let(:template) { chef_run.template('/etc/sysconfig/repose') }
+
+  it 'includes the recipe yum-epel' do
+    expect(chef_run).to include_recipe('yum-epel')
+  end
+
+  it 'sends a restart notification to the service' do
+    expect(template).to notify('service[repose-valve]').to(:restart)
+  end
+
+  it 'install the yum repository' do
+    expect(chef_run).to create_yum_repository('openrepose').with(
+      :baseurl => 'http://repo.openrepose.org/rhel',
+      :gpgkey => 'http://repo.openrepose.org/rhel/RPM_GPG_KEY-openrepose',
+      :gpgcheck => false,
+      :enabled => true
+    )
+  end
+
+  it 'creates the file /etc/init.d/repose-valve' do
+    expect(chef_run).to create_file('/etc/init.d/repose-valve')
+  end
+
+  it 'creates a template /etc/sysconfig/repose' do
+    expect(chef_run).to create_template('/etc/sysconfig/repose')
+  end
+  
+  packages = %w(repose-valve repose-filter-bundle repose-extensions-filter-bundle)
+  packages.each do |p|
+    it 'installs package #{p}' do
+      expect(chef_run).to install_package(p)
+    end
+  end
+end

--- a/test/unit/spec/install_spec.rb
+++ b/test/unit/spec/install_spec.rb
@@ -1,0 +1,18 @@
+require 'chefspec'
+require_relative 'spec_helper'
+
+describe 'repose::install' do
+  context 'rhel' do
+    let(:chef_run) { ChefSpec::SoloRunner.new( :platform => 'redhat', :version => '7.0' ).converge('repose::default',described_recipe) }
+    it 'includes the recipe repose::install_rhel' do
+      expect(chef_run).to include_recipe('repose::install_rhel')
+    end
+  end
+
+  context 'debian' do
+    let(:chef_run) { ChefSpec::SoloRunner.new( :platform => 'ubuntu', :version => '14.04' ).converge('repose::default',described_recipe) }
+    it 'includes the recipe repose::install_debian' do
+      expect(chef_run).to include_recipe('repose::install_debian')
+    end
+  end
+end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'rspec/expectations'
+require 'chefspec'
+require 'chefspec/berkshelf'
+require 'chef/application'
+
+def stub_resources
+end
+
+at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
# What

Add basic unit tests for default and install recipes.  Minor cleanup associated with the unit tests.

# Why 

We are depending on this cookbook downstream and it would be good to add unit tests in a more current chefspec model.

# How

Add test/unit/spec directory with some basic tests and a spec_helper.rb file.  Currently achieved 100% coverage on default.rb, install.rb, install_rhel.rb and install_debian.rb.

To test with ChefDK installed run $ chef exec rspec test/unit

# TODO

Continue to add more unit tests.  Add documentation on adding/running tests.