### PR TITLE
Clean up .kitchen.yml, fix issues for service-response-messaging

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,14 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
+- name: debian-7.9
+  driver_config:
+    box: opscode-debian-7.9
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.9_chef-provisionerless.box
+- name: debian-8.3
+  driver_config:
+    box: opscode-debian-8.3
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.3_chef-provisionerless.box
 - name: ubuntu-14.04
   driver_config:
     box: opscode-ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,14 +4,6 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
-- name: debian-7.9
-  driver_config:
-    box: opscode-debian-7.9
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.9_chef-provisionerless.box
-- name: debian-8.3
-  driver_config:
-    box: opscode-debian-8.3
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.3_chef-provisionerless.box
 - name: ubuntu-14.04
   driver_config:
     box: opscode-ubuntu-14.04
@@ -35,24 +27,27 @@ suites:
   run_list: [
     "apt",
     "java",
-    "recipe[repose::filter-slf4j-http-logging]",
+    "recipe[repose::default]",
+    "recipe[repose::filter-add-header]",
+    "recipe[repose::filter-api-validator]",
+    "recipe[repose::filter-client-auth]",
+    "recipe[repose::filter-client-authorization]",
+    "recipe[repose::filter-content-type-stripper]",
+    "recipe[repose::filter-derp]",
+    "recipe[repose::filter-header-identity]",
     "recipe[repose::filter-header-normalization]",
     "recipe[repose::filter-header-translation]",
-    "recipe[repose::filter-header-identity]",
     "recipe[repose::filter-ip-identity]",
-    "recipe[repose::filter-uri-identity]",
+    "recipe[repose::filter-keystone-v2]",
     "recipe[repose::filter-rackspace-auth-user]",
     "recipe[repose::filter-rate-limiting]",
+    "recipe[repose::filter-slf4j-http-logging]",
     "recipe[repose::filter-translation]",
-    "recipe[repose::filter-content-type-stripper]",
-    "recipe[repose::filter-client-authorization]",
+    "recipe[repose::filter-uri-identity]",
     "recipe[repose::filter-uri-stripper]",
-    "recipe[repose::filter-add-header]",
-    "recipe[repose::filter-keystone-v2]",
-    "recipe[repose::service-http-connection-pool]",
     "recipe[repose::service-dist-datastore]",
-    "recipe[repose::default]",
-    "recipe[minitest-handler]"
+    "recipe[repose::service-http-connection-pool]",
+    "recipe[repose::service-response-messaging]"
   ]
   attributes:
     java:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Services work the same way as filters. Just s/filter/service/g.
 
 Available services are:
   * [http-connection-pool] (https://repose.atlassian.net/wiki/display/REPOSE/HTTP+Connection+Pool+service) (configuration only)
-  * dist-datastore
+  * [dist-datastore] (https://repose.atlassian.net/wiki/display/REPOSE/Datastores#Datastores-distributedDistributedDatastore)
   * [response-messaging] (https://repose.atlassian.net/wiki/display/REPOSE/Response+Messaging+service)
 
 ## Nodes
@@ -463,7 +463,7 @@ Example hash of inserting headers into responses:
 
 ## response-messaging attributes
 
-* `node['repose']['response-messaging']['status_codes'] - Array of status codes to activate on and generate responses.
+* `node['repose']['response_messaging']['status_codes'] - Array of status codes to activate on and generate responses.
 Example of configuration:
 ```
 [{ 'id'         => 'test_bad_input',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,6 +79,8 @@ default['repose']['dist_datastore']['allow_all'] = false
 default['repose']['dist_datastore']['allowed_hosts'] = ['127.0.0.1']
 default['repose']['dist_datastore']['port'] = 8081
 
+default['repose']['response-messaging']['status_codes'] = []
+
 default['repose']['slf4j_http_logging']['cluster_id'] = ['all']
 default['repose']['slf4j_http_logging']['id'] = 'http'
 default['repose']['slf4j_http_logging']['format'] = 'Remote IP=%a Local IP=%A Response Size(bytes)=%b Remote Host=%h Request Method=%m Server Port=%p Query String=%q Time Request Received=%t Status=%s Remote User=%u Rate Limit Group: %{X-PP-Groups}i URL Path Requested=%U X-Forwarded-For=%{X-Forwarded-For}i X-REAL-IP=%{X-Real-IP}i'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,7 +79,7 @@ default['repose']['dist_datastore']['allow_all'] = false
 default['repose']['dist_datastore']['allowed_hosts'] = ['127.0.0.1']
 default['repose']['dist_datastore']['port'] = 8081
 
-default['repose']['response-messaging']['status_codes'] = []
+default['repose']['response_messaging']['status_codes'] = []
 
 default['repose']['slf4j_http_logging']['cluster_id'] = ['all']
 default['repose']['slf4j_http_logging']['id'] = 'http'

--- a/recipes/service-response-messaging.rb
+++ b/recipes/service-response-messaging.rb
@@ -10,6 +10,6 @@ template "#{node['repose']['config_directory']}/response-messaging.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    status_codes: node['repose']['response-messaging']['status_codes']
+    status_codes: node['repose']['response_messaging']['status_codes']
   )
 end

--- a/test/unit/spec/service-response-messaging_spec.rb
+++ b/test/unit/spec/service-response-messaging_spec.rb
@@ -17,7 +17,7 @@ describe 'repose::default' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
       node.set['repose']['services'] = ['response-messaging']
-      node.set['repose']['response-messaging']['status_codes'] = [{ 'id' => 'test_bad_input',
+      node.set['repose']['response_messaging']['status_codes'] = [{ 'id' => 'test_bad_input',
                                                                     'code_regex' => '4..',
                                                                     'messages'   => [
                                                                       { 'media_type' => 'application/xml',
@@ -68,7 +68,7 @@ describe 'repose::default' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
       node.set['repose']['services'] = ['response-messaging']
-      node.set['repose']['response-messaging']['status_codes'] = [{ 'id' => 'test_bad_input',
+      node.set['repose']['response_messaging']['status_codes'] = [{ 'id' => 'test_bad_input',
                                                                     'code_regex' => '4..',
                                                                     'overwrite'  => 'ALWAYS',
                                                                     'messages'   => [


### PR DESCRIPTION
This PR implements some minor cleanup in the .kitchen.yml file.  Followed up by verifying that a kitchen converge and kitchen verify runs on every flavor listed.
Note: This does not include the new filter-ip-user coming in next PR.

Fixed some issues with the naming of the response_messaging attribute which needed to use underscores instead of dashes.