### PR TITLE
Minor bug fix and version bump.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v3.3.3 (not tagged yet)
 ------
 * add optional content-body-read-limit, client-request-logging and proxy-thread-pool options to the container.cfg.xml template, set values to nil
 * added 10 additional options for the api-validator filter
+* fix minor bug with manually declared peers and system-model template
 
 v3.3.2
 ------

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cit-ops@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.3.2'
+version '3.3.3'
 issues_url 'https://github.com/rackerlabs/cookbook-repose/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackerlabs/cookbook-repose' if respond_to?(:source_url)
 

--- a/templates/default/system-model.cfg.xml.erb
+++ b/templates/default/system-model.cfg.xml.erb
@@ -11,7 +11,7 @@
     <% end %>
     >
         <nodes>
-            <% @nodes.each.sort do |node| %>
+            <% @nodes.each do |node| %>
               <% if node['cluster_id'].nil? || node['cluster_id'] == cluster_id %>
             <node id="<%= node['id'] %>" hostname="<%= node['hostname'] %>" http-port="<%= node['port'] %>" />
               <% end %>


### PR DESCRIPTION
# Description
Bumping to 3.3.3 after a few PRs with cleanup and added recipes.  Fixing a minor bug where declaring multiple peers via attributes (and not search) failed because of the .sort in system-model template.