### PR TITLE
cookbook nits and minor fixes.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,6 +79,7 @@ default['repose']['dist_datastore']['allow_all'] = false
 default['repose']['dist_datastore']['allowed_hosts'] = ['127.0.0.1']
 default['repose']['dist_datastore']['port'] = 8081
 
+default['repose']['response_messaging']['cluster_id'] = ['all']
 default['repose']['response_messaging']['status_codes'] = []
 
 default['repose']['slf4j_http_logging']['cluster_id'] = ['all']
@@ -207,6 +208,7 @@ default['repose']['rate_limiting']['limit_groups'] = [
   }
 ]
 
+default['repose']['http_connection_pool']['cluster_id'] = ['all']
 default['repose']['http_connection_pool']['chunked_encoding'] = true
 default['repose']['http_connection_pool']['max_total'] = 400
 default['repose']['http_connection_pool']['max_per_route'] = 200
@@ -275,6 +277,7 @@ default['repose']['api_validator']['validator_name'] = nil
 default['repose']['api_validator']['validate_checker'] = nil
 default['repose']['api_validator']['check_headers'] = nil
 
+default['repose']['ip_user']['cluster_id'] = ['all']
 default['repose']['ip_user']['user_header_name'] = 'X-PP-User'
 default['repose']['ip_user']['user_header_quality'] = '0.4'
 default['repose']['ip_user']['group_header_name'] = 'X-PP-Groups'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,9 +25,12 @@ directory node['repose']['config_directory'] do
   mode '0755'
 end
 
+# http-connection-pool and response-messaging do not need to be included in the system-model.cfg.xml file
 services = node['repose']['services'].reject { |x| x == 'http-connection-pool' || x == 'response-messaging' }
 service_cluster_map = {
-  'dist-datastore' => node['repose']['dist_datastore']['cluster_id']
+  'dist-datastore' => node['repose']['dist_datastore']['cluster_id'],
+  'http-connection-pool' => node['repose']['http_connection_pool']['cluster_id'],
+  'response-messaging' => node['repose']['response_messaging']['cluster_id']
 }
 
 filters = node['repose']['filters']
@@ -100,10 +103,12 @@ template "#{node['repose']['config_directory']}/container.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
+    content_body_read_limit: node['repose']['content_body_read_limit'],
     connection_timeout: node['repose']['connection_timeout'],
     read_timeout: node['repose']['read_timeout'],
     deploy_auto_clean: node['repose']['deploy_auto_clean'],
     filter_check_interval: node['repose']['filter_check_interval'],
+    client_request_logging: node['repose']['client_request_logging'],
     version: node['repose']['version']
   )
   notifies :restart, 'service[repose-valve]'

--- a/recipes/filter-api-validator.rb
+++ b/recipes/filter-api-validator.rb
@@ -15,11 +15,27 @@ template "#{node['repose']['config_directory']}/validator.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
+    version: node['repose']['version'],
     wadl: node['repose']['api_validator']['wadl'],
     dot_output: node['repose']['api_validator']['dot_output'],
     enable_rax_roles: node['repose']['api_validator']['enable_rax_roles'],
-    version: node['repose']['version'],
-    enable_api_coverage: node['repose']['api_validator']['enable_api_coverage']
+    enable_api_coverage: node['repose']['api_validator']['enable_api_coverage'],
+    check_well_formed: node['repose']['api_validator']['check_well_formed'],
+    check_grammars: node['repose']['api_validator']['check_grammars'],
+    check_elements: node['repose']['api_validator']['check_elements'],
+    check_plain_params: node['repose']['api_validator']['check_plain_params'],
+    do_xsd_grammar_transform: node['repose']['api_validator']['do_xsd_grammar_transform'],
+    enable_pre_process_extension: node['repose']['api_validator']['enable_pre_process_extension'],
+    remove_dups: node['repose']['api_validator']['remove_dups'],
+    xpath_version: node['repose']['api_validator']['xpath_version'],
+    xsl_engine: node['repose']['api_validator']['xsl_engine'],
+    xsd_engine: node['repose']['api_validator']['xsd_engine'],
+    mask_rax_roles_403: node['repose']['api_validator']['mask_rax_roles_403'],
+    join_xpath_checks: node['repose']['api_validator']['join_xpath_checks'],
+    enable_ignore_xsd_extension: node['repose']['api_validator']['enable_ignore_xsd_extension'],
+    validator_name: node['repose']['api_validator']['validator_name'],
+    validate_checker: node['repose']['api_validator']['validate_checker'],
+    check_headers: node['repose']['api_validator']['check_headers']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/templates/default/container.cfg.xml.erb
+++ b/templates/default/container.cfg.xml.erb
@@ -6,7 +6,7 @@
 <% else %>
 <repose-container xmlns='http://docs.openrepose.org/repose/container/v2.0'>
 <% end %>
-    <deployment-config <% if @content_body_read_limit != nil %>content-body-read-limit="<% @content_body_read_limit %>"<% end %> connection-timeout="<%= @connection_timeout %>" read-timeout="<%= @read_timeout %>" <% if @client_request_logging != nil %>client-request-logging="<%= @client_request_logging %>"<% end %> <% if @proxy_thread_pool != nil %>proxy-thread-pool="<%= @proxy_thread_pool %>"<% end %>>
+    <deployment-config <% if @content_body_read_limit != nil %>content-body-read-limit="<%= @content_body_read_limit %>"<% end %> connection-timeout="<%= @connection_timeout %>" read-timeout="<%= @read_timeout %>" <% if @client_request_logging != nil %>client-request-logging="<%= @client_request_logging %>"<% end %> <% if @proxy_thread_pool != nil %>proxy-thread-pool="<%= @proxy_thread_pool %>"<% end %>>
         <deployment-directory auto-clean="<%= @deploy_auto_clean %>">/var/repose</deployment-directory>
         <artifact-directory check-interval="<%= @filter_check_interval %>">/usr/share/repose/filters</artifact-directory>
 <% if @version.nil? || @version.split('.')[0].to_i > 6 %>

--- a/templates/default/ip-user.cfg.xml.erb
+++ b/templates/default/ip-user.cfg.xml.erb
@@ -7,7 +7,7 @@
     <% @groups.each do |group| %>
     <group name=<%= group['group_name'] %>>
        <% group['cidrips'].each do |ip| %>
-       <cidr-ips><%= ip['ip'] %><cidr-ips>"
+       <cidr-ip><%= ip %></cidr-ip>"
        <% end %>
     </group>
     <% end %>

--- a/templates/default/keystone-v2.cfg.xml.erb
+++ b/templates/default/keystone-v2.cfg.xml.erb
@@ -38,17 +38,9 @@
     <% end %>
 
     <% if @tenant_handling %>
-    <tenant-handling 
-        <% if @tenant_handling['send_all_tenant_ids'] %>
-         send-all-tenant-ids="<%= @tenant_handling['send_all_tenant_ids'] %>"
-        <% end %>
-        >
+    <tenant-handling<% if @tenant_handling['send_all_tenant_ids'] %> send-all-tenant-ids="<%= @tenant_handling['send_all_tenant_ids'] %>"<% end %>>
         <% if @tenant_handling['validate_tenant'] %>
-            <validate-tenant 
-            <% if @tenant_handling['validate_tenant']['strip_token_tenant_prefixes'] %>			
-                strip-token-tenant-prefixes="<%= @@tenant_handling['validate_tenant']['strip_token_tenant_prefixes'] %>"
-            <% end %>
-            >
+            <validate-tenant<% if @tenant_handling['validate_tenant']['strip_token_tenant_prefixes'] -%> strip-token-tenant-prefixes="<%= @tenant_handling['validate_tenant']['strip_token_tenant_prefixes'] %>"<% end -%>>
 	    <uri-extraction-regex><%= @tenant_handling['validate_tenant']['url_extraction_regex'] %></uri-extraction-regex>
 	</validate-tenant>
 	<% end %>

--- a/templates/default/validator.cfg.xml.erb
+++ b/templates/default/validator.cfg.xml.erb
@@ -10,25 +10,63 @@
       role="default"
       default="true"
       wadl="<%= @wadl %>"
-      <% if @dot_output != nil %>dot-output="<%= @dot_output %>"<% end %>
-      <% if @enable_rax_roles != nil %>enable-rax-roles="<%= @enable_rax_roles %>"<% end %>
-      <% if @enable_api_coverage != nil %>enable-api-coverage="<%= @enable_api_coverage %>"<% end %>
-      <% if @check_well_formed != nil %>check-well-formed="<%= @check_well_formed %>"<% end %>
-      <% if @check_grammars != nil %>check-grammars="<%= @check_grammars %>"<% end %>
-      <% if @check_elements != nil %>check-elements="<%= @check_elements %>"<% end %>
-      <% if @check_plain_params != nil %>check-plain-params="<%= @check_plain_params %>"<% end %>
-      <% if @do_xsd_grammar_transform != nil %>do-xsd-grammar-transform="<%= @do_xsd_grammar_transform %>"<% end %>
-      <% if @enable_pre_process_extension != nil %>enable-pre-process-extension="<%= @enable_pre_process_extension %>"<% end %>
-      <% if @remove_dups != nil %>remove-dups="<%= @remove_dups %>"<% end %>
-      <% if @xpath_version != nil %>xpath-version="<%= @xpath_version %>"<% end %>
-      <% if @xsl_engine != nil %>xsl-engine="<%= @xsl_engine %>"<% end %>
-      <% if @xsd_engine != nil %>xsd-engine="<%= @xsd_engine %>"<% end %>
-      <% if @mask_rax_roles_403 != nil %>mask-rax-roles-403="<%= @mask_rax_roles_403 %>"<% end %>
-      <% if @join_xpath_checks != nil %>join-xpath-checks="<%= @join_xpath_checks %>"<% end %>
-      <% if @enable_ignore_xsd_extension != nil %>enable-ignore-xsd-extension="<%= @enable_ignore_xsd_extension %>"<% end %>
-      <% if @validator_name != nil %>validator-name="<%= @validator_name %>"<% end %>
-      <% if @validate_checker != nil %>validate-checker="<%= @validate_checker %>"<% end %>
-      <% if @check_headers != nil %>check-headers="<%= @check_headers %>"<% end %>
+      <% if @dot_output != nil -%>
+      dot-output="<%= @dot_output %>"
+      <% end -%>
+      <% if @enable_rax_roles != nil -%>
+      enable-rax-roles="<%= @enable_rax_roles %>"
+      <% end -%>
+      <% if @enable_api_coverage != nil -%>
+      enable-api-coverage="<%= @enable_api_coverage %>"
+      <% end -%>
+      <% if @check_well_formed != nil -%>
+      check-well-formed="<%= @check_well_formed %>"
+      <% end -%>
+      <% if @check_grammars != nil -%>
+      check-grammars="<%= @check_grammars %>"
+      <% end -%>
+      <% if @check_elements != nil -%>
+      check-elements="<%= @check_elements %>"
+      <% end -%>
+      <% if @check_plain_params != nil -%>
+      check-plain-params="<%= @check_plain_params %>"
+      <% end -%>
+      <% if @do_xsd_grammar_transform != nil -%>
+      do-xsd-grammar-transform="<%= @do_xsd_grammar_transform %>"
+      <% end -%>
+      <% if @enable_pre_process_extension != nil -%>
+      enable-pre-process-extension="<%= @enable_pre_process_extension %>"
+      <% end -%>
+      <% if @remove_dups != nil -%>
+      remove-dups="<%= @remove_dups %>"
+      <% end -%>
+      <% if @xpath_version != nil -%>
+      xpath-version="<%= @xpath_version %>"
+      <% end -%>
+      <% if @xsl_engine != nil -%>
+      xsl-engine="<%= @xsl_engine %>"
+      <% end -%>
+      <% if @xsd_engine != nil -%>
+      xsd-engine="<%= @xsd_engine %>"
+      <% end -%>
+      <% if @mask_rax_roles_403 != nil -%>
+      mask-rax-roles-403="<%= @mask_rax_roles_403 %>"
+      <% end -%>
+      <% if @join_xpath_checks != nil -%>
+      join-xpath-checks="<%= @join_xpath_checks %>"
+      <% end -%>
+      <% if @enable_ignore_xsd_extension != nil -%>
+      enable-ignore-xsd-extension="<%= @enable_ignore_xsd_extension %>"
+      <% end -%>
+      <% if @validator_name != nil -%>
+      validator-name="<%= @validator_name %>"
+      <% end -%>
+      <% if @validate_checker != nil -%>
+      validate-checker="<%= @validate_checker %>"
+      <% end -%>
+      <% if @check_headers != nil -%>
+      check-headers="<%= @check_headers %>"
+      <% end -%>
     />
 </validators>
 


### PR DESCRIPTION
## Description
In working towards deploying Repose 7.x in Rackspace Metrics environment I have found some small bugs and small formatting nits.  Several small fixes below.

attributes/default.rb - add some default values for services cluster_id to match up
recipes/default.rb - add services to server_cluster_map to match others, add missing variables in container template resource
recipes/filter-api-validator.rb - add missing variables that need to be passed to template resource if they exist
templates/default/container.cfg.xml.erb - fix variable bug
templates/default/ip-user.cfg.xml.erb - fix incorrect variable naming
templates/default/keystone-v2.cfg.xml.erb - fix formatting so that output doesn't show up with blank lines/spaces
templates/default/validator.cfg.xml.erb - fix formatting so that blank lines don't show for variables which are nil


