### PR TITLE
continued 3.3.4 development

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -184,6 +184,10 @@ default['repose']['client_authorization']['roles'] = []
 default['repose']['client_authorization']['delegating_quality'] = nil
 
 default['repose']['rate_limiting']['cluster_id'] = ['all']
+default['repose']['rate_limiting']['datastore'] = nil
+default['repose']['rate_limiting']['datastore_warn_limit'] = nil
+default['repose']['rate_limiting']['overlimit_429_responsecode'] = nil
+default['repose']['rate_limiting']['use_capture_groups'] = nil
 default['repose']['rate_limiting']['uri_regex'] = '/limits'
 default['repose']['rate_limiting']['global_limits'] = []
 default['repose']['rate_limiting']['include_absolute_limits'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -253,6 +253,7 @@ default['repose']['add_header']['requests'] = []
 default['repose']['add_header']['responses'] = []
 
 default['repose']['api_validator']['cluster_id'] = ['all']
+default['repose']['api_validator']['multi_role_match'] = nil
 default['repose']['api_validator']['enable_rax_roles'] = true
 default['repose']['api_validator']['wadl'] = nil
 default['repose']['api_validator']['dot_output'] = '/tmp/default.out'

--- a/recipes/filter-api-validator.rb
+++ b/recipes/filter-api-validator.rb
@@ -16,6 +16,7 @@ template "#{node['repose']['config_directory']}/validator.cfg.xml" do
   mode '0644'
   variables(
     version: node['repose']['version'],
+    multi_role_match: node['repose']['api_validator']['multi_role_match'],
     wadl: node['repose']['api_validator']['wadl'],
     dot_output: node['repose']['api_validator']['dot_output'],
     enable_rax_roles: node['repose']['api_validator']['enable_rax_roles'],

--- a/recipes/filter-rate-limiting.rb
+++ b/recipes/filter-rate-limiting.rb
@@ -15,6 +15,10 @@ template "#{node['repose']['config_directory']}/rate-limiting.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
+    datastore: node['repose']['rate_limiting']['datastore'],
+    datastore_warn_limit: node['repose']['rate_limiting']['datastore_warn_limit'],
+    overlimit_429_responsecode: node['repose']['rate_limiting']['overlimit_429_responsecode'],
+    use_capture_groups: node['repose']['rate_limiting']['use_capture_groups'],
     uri_regex: node['repose']['rate_limiting']['uri_regex'],
     global_limits: node['repose']['rate_limiting']['global_limits'],
     include_absolute_limits: node['repose']['rate_limiting']['include_absolute_limits'],

--- a/templates/default/rate-limiting.cfg.xml.erb
+++ b/templates/default/rate-limiting.cfg.xml.erb
@@ -3,7 +3,7 @@
 <% if !@version.nil? && @version.split('.')[0].to_i < 7 %>
 <rate-limiting xmlns="http://docs.rackspacecloud.com/repose/rate-limiting/v1.0">
 <% else %>
-<rate-limiting <% if @datastore %><datastore="<% @datastore %>"> <% end ><% if @datastore_warn_limit %><datastore-warn-limit="<% @datastore_warn_limit %>"> <% end %><% if @overlimit_429_responsecode %><overlimit-429-responseCode="<% @overlimit_429_responsecode %>"> <% end %><% if @use_capture_groups %><use-capture-groups="<% @use_capture_groups %>"> <% end %><xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
+<rate-limiting <% if @datastore %>datastore="<% @datastore %>" <% end ><% if @datastore_warn_limit %>datastore-warn-limit="<% @datastore_warn_limit %>" <% end %><% if @overlimit_429_responsecode %>overlimit-429-responseCode="<% @overlimit_429_responsecode %>" <% end %><% if @use_capture_groups %>use-capture-groups="<% @use_capture_groups %>" <% end %><xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
 <% end %>
 
 <!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->

--- a/templates/default/rate-limiting.cfg.xml.erb
+++ b/templates/default/rate-limiting.cfg.xml.erb
@@ -3,7 +3,7 @@
 <% if !@version.nil? && @version.split('.')[0].to_i < 7 %>
 <rate-limiting xmlns="http://docs.rackspacecloud.com/repose/rate-limiting/v1.0">
 <% else %>
-<rate-limiting xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
+<rate-limiting <% if @datastore %><datastore="<% @datastore %>"> <% end ><% if @datastore_warn_limit %><datastore-warn-limit="<% @datastore_warn_limit %>"> <% end %><% if @overlimit_429_responsecode %><overlimit-429-responseCode="<% @overlimit_429_responsecode %>"> <% end %><% if @use_capture_groups %><use-capture-groups="<% @use_capture_groups %>"> <% end %><xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
 <% end %>
 
 <!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->

--- a/templates/default/validator.cfg.xml.erb
+++ b/templates/default/validator.cfg.xml.erb
@@ -2,9 +2,9 @@
 
 <!-- https://repose.atlassian.net/wiki/display/REPOSE/API+Validation+filter -->
 <% if !@version.nil? && @version.split('.')[0].to_i < 7 %>
-<validators <% if @multi_role_match %>multi-role-match=<% @multi_role_match %><% end %> xmlns='http://openrepose.org/repose/validator/v1.0'>
+<validators multi-role-match="true" xmlns='http://openrepose.org/repose/validator/v1.0'>
 <% else %>
-<validators multi-role-match="true" xmlns='http://docs.openrepose.org/repose/validator/v1.0'>
+<validators <% if @multi_role_match %>multi-role-match="<% @multi_role_match %>" <% end %> xmlns='http://docs.openrepose.org/repose/validator/v1.0'>
 <% end %>
    <validator
       role="default"

--- a/templates/default/validator.cfg.xml.erb
+++ b/templates/default/validator.cfg.xml.erb
@@ -2,7 +2,7 @@
 
 <!-- https://repose.atlassian.net/wiki/display/REPOSE/API+Validation+filter -->
 <% if !@version.nil? && @version.split('.')[0].to_i < 7 %>
-<validators multi-role-match="true" xmlns='http://openrepose.org/repose/validator/v1.0'>
+<validators <% if @multi_role_match %>multi-role-match=<% @multi_role_match %><% end %> xmlns='http://openrepose.org/repose/validator/v1.0'>
 <% else %>
 <validators multi-role-match="true" xmlns='http://docs.openrepose.org/repose/validator/v1.0'>
 <% end %>


### PR DESCRIPTION
## What
Add additional attributes for filter-api-validator recipe.  The API Validation filter has several variables we don't include - this finished optional attributes for the rate-limiting element.
Set the multi-role-match attribute of the validators element to be optional, it will be deprecated in the upcoming Repose v8.

## How
Updated templates, recipes and default attributes.