### PR TITLE
Update log4j2 template to have better rotation by default

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,11 @@
 
-v3.3.3 (not tagged yet)
+v3.3.4
+------
+* update log4j2.xml template to use numbers in log rotation instead of date
+* pin default version to 7.3.6.0 to avoid JRE 8 issues (until tested later)
+* filter template updates - api-validator, rate-limiting, keystone-v2, slf4j-http-logging
+
+v3.3.3
 ------
 * add optional content-body-read-limit, client-request-logging and proxy-thread-pool options to the container.cfg.xml template, set values to nil
 * added 10 additional options for the api-validator filter

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@ when 'debian'
   default['repose']['install_opts'] = '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes'
 end
 
-default['repose']['version'] = nil
+default['repose']['version'] = '7.3.6.0'
 default['repose']['loglevel'] = 'DEBUG'
 default['repose']['cluster_ids'] = ['repose']
 default['repose']['rewrite_host_header'] = true

--- a/templates/default/log4j2.xml.erb
+++ b/templates/default/log4j2.xml.erb
@@ -5,12 +5,12 @@
             <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>
         </Console>
         <RollingFile name="RollingFile" fileName="/var/log/repose/current.log"
-                     filePattern="/var/log/repose/current-%d{yyyy-MM-dd_HHmmss}.log">
+                     filePattern="/var/log/repose/current-%i.log">
             <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>
             <Policies>
-                <SizeBasedTriggeringPolicy size="200 MB"/>
+                <SizeBasedTriggeringPolicy size="1024 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="2"/>
+            <DefaultRolloverStrategy max="5"/>
         </RollingFile>
         <% @appenders.each do |appender| %>
             <%= appender %>


### PR DESCRIPTION
# What
Update configuration for default log in log4j2.xml.erb template.  The current version had a date string in the filename portion, but that doesn't work properly with the DefaultRolloverStrategy attribute.
Set the default version to 7.3.6.0 (was nil) as version 8.x.x.x has been released now and deprecates Java 7.

# How
Switch to using a numeric value using %i, drop the date naming.  Change the default set to 5 logs of 1024MB each.
Update attributes with version.  Update CHANGELOG.

# Todo
Tag as version 3.3.4 after PR is reviewed and merged.

# Reference
http://stackoverflow.com/questions/13502722/log4j2-limiting-the-number-of-log-files
http://stackoverflow.com/questions/24551768/how-does-log4j2-defaultrolloverstrategys-max-attribute-really-work