### PR TITLE
version 3.3.5 - fix overLimit-429-responsecode bug

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+v3.3.5
+------
+* fix bug where overLimit-429-responsecode attribute had incorrect casing (rate-limiting.cfg.xml template)
+* change default logging to WARN instead of DEBUG (log4j2.xml.erb)
+* change default log rotation to 512MB and 4 files (log4j2.xml.erb)
 
 v3.3.4
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@ when 'debian'
 end
 
 default['repose']['version'] = '7.3.6.0'
-default['repose']['loglevel'] = 'DEBUG'
+default['repose']['loglevel'] = 'WARN'
 default['repose']['cluster_ids'] = ['repose']
 default['repose']['rewrite_host_header'] = true
 default['repose']['node_id'] = 'repose_node1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cit-ops@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.3.3'
+version '3.3.5'
 issues_url 'https://github.com/rackerlabs/cookbook-repose/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackerlabs/cookbook-repose' if respond_to?(:source_url)
 

--- a/templates/default/log4j2.xml.erb
+++ b/templates/default/log4j2.xml.erb
@@ -8,9 +8,9 @@
                      filePattern="/var/log/repose/current-%i.log">
             <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>
             <Policies>
-                <SizeBasedTriggeringPolicy size="1024 MB"/>
+                <SizeBasedTriggeringPolicy size="512 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="5"/>
+            <DefaultRolloverStrategy max="4"/>
         </RollingFile>
         <% @appenders.each do |appender| %>
             <%= appender %>

--- a/templates/default/rate-limiting.cfg.xml.erb
+++ b/templates/default/rate-limiting.cfg.xml.erb
@@ -3,7 +3,7 @@
 <% if !@version.nil? && @version.split('.')[0].to_i < 7 %>
 <rate-limiting xmlns="http://docs.rackspacecloud.com/repose/rate-limiting/v1.0">
 <% else %>
-<rate-limiting <% if !@datastore.nil? %>datastore="<%= @datastore %>" <% end %><% if !@datastore_warn_limit.nil? %>datastore-warn-limit="<%= @datastore_warn_limit %>" <% end %><% if !@overlimit_429_responsecode.nil? %>overlimit-429-responseCode="<%= @overlimit_429_responsecode %>" <% end %><% if !@use_capture_groups.nil? %>use-capture-groups="<%= @use_capture_groups %>" <% end %>xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
+<rate-limiting <% if !@datastore.nil? %>datastore="<%= @datastore %>" <% end %><% if !@datastore_warn_limit.nil? %>datastore-warn-limit="<%= @datastore_warn_limit %>" <% end %><% if !@overlimit_429_responsecode.nil? %>overLimit-429-responseCode="<%= @overlimit_429_responsecode %>" <% end %><% if !@use_capture_groups.nil? %>use-capture-groups="<%= @use_capture_groups %>" <% end %>xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
 <% end %>
 
 <!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->


### PR DESCRIPTION
# What
Bump to version 3.3.5.  Fix a case error for the overLimit-429-responsecode attribute in the rate-limiting.cfg.xml template.  Update basic logging defaults to be less of a hog.

# How
Updates in templates and to metadata.rb.

# TODO
After review and merge, tag as 3.3.5.
