### PR TITLE
fixing keystone-v2 whitelist xml tags.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cit-ops@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.3.5'
+version '3.3.6'
 issues_url 'https://github.com/rackerlabs/cookbook-repose/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackerlabs/cookbook-repose' if respond_to?(:source_url)
 

--- a/templates/default/keystone-v2.cfg.xml.erb
+++ b/templates/default/keystone-v2.cfg.xml.erb
@@ -25,7 +25,7 @@
     <% if @white_list %>
     <white-list>
 	<% @white_list.each do | uri_regex | %>
-        <uri-pattern uri-regex="<%= uri_regex %>" />
+        <uri-regex><%= uri_regex %>"</uri-regex>
 	<% end %>
     </white-list>
     <% end %>


### PR DESCRIPTION
The existing XML tags in the template are incorrect.  fixing.