### PR TITLE
Update enable_api_coverage and enable_rax_roles attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -258,11 +258,8 @@ default['repose']['add_header']['responses'] = []
 
 default['repose']['api_validator']['cluster_id'] = ['all']
 default['repose']['api_validator']['multi_role_match'] = nil
-default['repose']['api_validator']['enable_rax_roles'] = true
 default['repose']['api_validator']['wadl'] = nil
 default['repose']['api_validator']['dot_output'] = '/tmp/default.out'
-default['repose']['api_validator']['enable_rax_roles'] = false
-default['repose']['api_validator']['enable_api_coverage'] = true
 default['repose']['api_validator']['enable_rax_roles'] = nil
 default['repose']['api_validator']['enable_api_coverage'] = nil
 default['repose']['api_validator']['check_well_formed'] = nil


### PR DESCRIPTION
# Description
 Previously enable_rax_roles was set to both true and false.  enable_api_coverage was set to true.  They are both optional to the API Validator filter, so they should be set to nil in the attributes/default.rb file.