### PR TITLE
should be .sort.each vs .each.sort

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+v3.3.7
+------
+* fix allowed_hosts sorting bug which broke dist-datastore
+
+v3.3.6
+------
+
 v3.3.5
 ------
 * fix bug where overLimit-429-responsecode attribute had incorrect casing (rate-limiting.cfg.xml template)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cit-ops@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.3.6'
+version '3.3.7'
 issues_url 'https://github.com/rackerlabs/cookbook-repose/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackerlabs/cookbook-repose' if respond_to?(:source_url)
 

--- a/templates/default/dist-datastore.cfg.xml.erb
+++ b/templates/default/dist-datastore.cfg.xml.erb
@@ -10,7 +10,7 @@
     <allowed-hosts allow-all="true" />
     <% else %>
     <allowed-hosts allow-all="false">
-        <% @allowed_hosts.each.sort do |host| %>
+        <% @allowed_hosts.sort.each do |host| %>
         <allow host="<%= host %>" />
         <% end %>
     </allowed-hosts>


### PR DESCRIPTION
Fix allowed_hosts sorting bug in dist-datastore template.