### PR TITLE
fix for .kitchen.docker.yml to run Travis Centos7 tests

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,3 +1,16 @@
 driver:
   name: docker
   privileged: true
+
+platforms:
+  - name: debian-7.9
+  - name: debian-8.3
+  - name: ubuntu-14.04
+  - name: ubuntu-12.04
+  - name: centos-6.7
+  - name: centos-7.2
+    driver_config:
+      image: centos:7
+      provision_command: yum -y install initscripts
+      run_command: /usr/sbin/init
+      privileged: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,8 +1,7 @@
 driver:
   name: vagrant
-
-driver_config:
-  require_chef_omnibus: true
+  driver_config:
+    require_chef_omnibus: true
 
 platforms:
 - name: debian-7.9


### PR DESCRIPTION
This should enable systemd to run in the CentOS7 container in Travis and pass tests.