### PR TITLE
fix mode on files which have credentials

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+v3.3.8
+------
+* update default mode on files which have credentials
+
 v3.3.7
 ------
 * fix allowed_hosts sorting bug which broke dist-datastore

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cit-ops@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.3.7'
+version '3.3.8'
 issues_url 'https://github.com/rackerlabs/cookbook-repose/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackerlabs/cookbook-repose' if respond_to?(:source_url)
 

--- a/recipes/filter-client-auth.rb
+++ b/recipes/filter-client-auth.rb
@@ -13,7 +13,7 @@ end
 template "#{node['repose']['config_directory']}/client-auth-n.cfg.xml" do
   owner node['repose']['owner']
   group node['repose']['group']
-  mode '0644'
+  mode '0640'
   variables(
     auth_provider: node['repose']['client_auth']['auth_provider'],
     username: node['repose']['client_auth']['username_admin'],

--- a/recipes/filter-client-authorization.rb
+++ b/recipes/filter-client-authorization.rb
@@ -13,7 +13,7 @@ end
 template "#{node['repose']['config_directory']}/openstack-authorization.cfg.xml" do
   owner node['repose']['owner']
   group node['repose']['group']
-  mode '0644'
+  mode '0640'
   variables(
     username: node['repose']['client_authorization']['username_admin'],
     password: node['repose']['client_authorization']['password_admin'],

--- a/recipes/filter-keystone-v2.rb
+++ b/recipes/filter-keystone-v2.rb
@@ -13,7 +13,7 @@ end
 template "#{node['repose']['config_directory']}/keystone-v2.cfg.xml" do
   owner node['repose']['owner']
   group node['repose']['group']
-  mode '0644'
+  mode '0640'
   variables(
     username: node['repose']['keystone_v2']['username_admin'],
     password: node['repose']['keystone_v2']['password_admin'],


### PR DESCRIPTION
# Description
Fix permissions on client-auth, keystone-v2 and openstack-authorization files in /etc/repose.  Those files were 0644 and should at most be 0640.

# Todo
After review, tag a version at 3.3.8.