### PR TITLE
Fix repose pkgs installation method

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,8 +21,8 @@ end
 
 default['repose']['packages'] = [
     'repose-valve',
-    ' repose-filter-bundle',
-    ' repose-extensions-filter-bundle'
+    'repose-filter-bundle',
+    'repose-extensions-filter-bundle'
 ]
 
 default['repose']['version'] = '8.8.3.0'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,12 @@ when 'debian'
   default['repose']['install_opts'] = '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes'
 end
 
+default['repose']['packages'] = [
+    'repose-valve',
+    ' repose-filter-bundle',
+    ' repose-extensions-filter-bundle'
+]
+
 default['repose']['version'] = '8.8.3.0'
 default['repose']['loglevel'] = 'WARN'
 default['repose']['cluster_ids'] = ['repose']

--- a/recipes/install_debian.rb
+++ b/recipes/install_debian.rb
@@ -17,11 +17,8 @@ apt_repository 'openrepose' do
   only_if { node['repose']['repo']['managed'] }
 end
 
-%w[repose-valve
-   repose-filter-bundle
-   repose-extensions-filter-bundle].each do |p|
-  package p do
-    options node['repose']['install_opts']
-    version node['repose']['version']
-  end
+pkgs = node['repose']['packages'].map{ |p| [p, node['repose']['version']].join('=')}
+
+bash 'install repose packages' do
+  code "apt #{node['repose']['install_opts']} install #{pkgs.join(' ')}"
 end

--- a/recipes/install_debian.rb
+++ b/recipes/install_debian.rb
@@ -17,7 +17,9 @@ apt_repository 'openrepose' do
   only_if { node['repose']['repo']['managed'] }
 end
 
-pkgs = node['repose']['packages'].map{ |p| [p, node['repose']['version']].join('=')}
+pkgs = node['repose']['packages'].map do |p|
+  [p, node['repose']['version']].join('=')
+end
 
 bash 'install repose packages' do
   code "apt #{node['repose']['install_opts']} install #{pkgs.join(' ')}"


### PR DESCRIPTION
Changing the way we install repose-valve and dependent packages, because if the packages are installed one by one, repose 9.1 creeps in when we install repose-valve due to some inter-dependency.