### PR TITLE
Reduce repose request tracing logs

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'cookbook-repose@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.6.0'
+version '3.6.1'
 chef_version '>= 12' if respond_to?(:chef_version)
 issues_url 'https://github.com/rackerlabs/cookbook-repose/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackerlabs/cookbook-repose' if respond_to?(:source_url)

--- a/templates/default/log4j2.xml.erb
+++ b/templates/default/log4j2.xml.erb
@@ -28,6 +28,8 @@
         <Logger name="org.springframework" level="warn"/>
         <Logger name="org.openrepose" level="<%= @openrepose_loglevel %>"/>
         <Logger name="intrafilter-logging" level="<%= @intrafilter_loglevel %>"/>
+        # This logger logs the trace id of each request, which isn't too useful and fills up logs.
+        <Logger name="org.openrepose.powerfilter.PowerFilter.trace-id-logging" level="off"/>
         <Logger name="com.uber.jaeger" level="<%= @tracing_log_level %>"/>
         <% @loggers.each do |logger| %>
             <%= logger %>


### PR DESCRIPTION
Repose is logging out a line at info level for each request that basically only contains the unique request/transaction id. They look like this:

    Trans-Id:462d1c98-21ee-4041-9117-d9563fb9e054 - 2022-01-18 16:00:14,753 34371166201 [qtp1966366279-481452] INFO  org.openrepose.powerfilter.PowerFilter.trace-id-logging - Tracing header: {"requestId":"462d1c98-21ee-4041-9117-d9563fb9e054","origin":null}

Without any other context, it's pretty useless, but they outnumber other logs by a couple hundred to one:

    $ sudo cat /var/log/repose/current.1.log | grep 'trace-id-logging - Tracing header' | wc -l
    823883
    $ sudo cat /var/log/repose/current.1.log | grep -v 'trace-id-logging - Tracing header' | wc -l
    3983

We can add a line to repose's log4j config to turn off these logs when we don't need them.


[This change](https://github.com/rax-maas/chef/pull/5493) was also done in Chef earlier.