### PR TITLE
Update the add-header filter template

### DIFF
--- a/templates/default/add-header.cfg.xml.erb
+++ b/templates/default/add-header.cfg.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<% if @version.nil? || @version.split('.')[0].to_i > 6 %>
+<% if @version.nil? || @version.split('.')[0].to_i < 6 %>
 <add-headers xmlns="http://docs.api.rackspacecloud.com/repose/add-header/v1.0">
 <% else %>
 <add-headers xmlns="http://docs.openrepose.org/repose/add-header/v1.0">


### PR DESCRIPTION
While updating the repose for blueflood-chef, we found out that this condition is wrong. So reversed the condition as with new version rackspace link is not valid.