### PR TITLE
bump metadata version to 3.6.4

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'cookbook-repose@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.6.1'
+version '3.6.4'
 chef_version '>= 12' if respond_to?(:chef_version)
 issues_url 'https://github.com/rackerlabs/cookbook-repose/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackerlabs/cookbook-repose' if respond_to?(:source_url)


### PR DESCRIPTION
there have been two releases, 3.6.2, and 3.6.3 where the metadata.rb
file has not been updated. this leads to an inconsistency in the
Berksfile.lock when updating to either of these versions, as you have
3.6.x in the Berksfile, but a `berks update|install` will still write
the (older) version listed in metadata.rb into the Berksfile.lock
