### PR TITLE
fix for --force-yes removal from apt install

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@ when 'debian'
   default['repose']['repo']['baseurl'] = 'http://repo.openrepose.org/debian'
   default['repose']['repo']['gpgkey'] = 'http://repo.openrepose.org/debian/pubkey.gpg'
   default['repose']['repo']['managed'] = true
-  default['repose']['install_opts'] = '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes'
+  default['repose']['install_opts'] = '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --allow-downgrades --allow-change-held-packages --yes'
 end
 
 default['repose']['packages'] = [


### PR DESCRIPTION
apt `--force-yes` option is deprecated and has no effect to force install the packages. For repose upgrade/downgrade, packages need corresponding force install option.

Without fix, chef-client run logs:
```
==> default:     ================================================================================
==> default:     Error executing action `run` on resource 'bash[install repose packages]'
==> default:     ================================================================================
==> default:
==> default:     Mixlib::ShellOut::ShellCommandFailed
==> default:     ------------------------------------
==> default:     Expected process to exit with [0], but received '1'
==> default:     ---- Begin output of "bash"  "/tmp/chef-script20240501-30886-1n54b6h" ----
==> default:     STDOUT: Reading package lists...
==> default:     Building dependency tree...
==> default:     Reading state information...
==> default:     Suggested packages:
==> default:       repose-extensions-bundle
==> default:     The following held packages will be changed:
==> default:       repose-extensions-filter-bundle repose-filter-bundle repose-valve
==> default:     The following packages will be upgraded:
==> default:       repose-extensions-filter-bundle repose-filter-bundle repose-valve
==> default:     3 upgraded, 0 newly installed, 0 to remove and 7 not upgraded.
==> default:     Need to get 206 MB of archives.
==> default:     After this operation, 26.1 MB of additional disk space will be used.
==> default:     Do you want to continue? [Y/n] Abort.
==> default:     STDERR: WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
==> default:     ---- End output of "bash"  "/tmp/chef-script20240501-30886-1n54b6h" ----
==> default:     Ran "bash"  "/tmp/chef-script20240501-30886-1n54b6h" returned 1
==> default:
==> default:     Resource Declaration:
==> default:     ---------------------
==> default:     # In /var/chef/cache/cookbooks/repose/recipes/install_debian.rb
==> default:
==> default:      24: bash 'install repose packages' do
==> default:      25:   code "apt #{node['repose']['install_opts']} install #{pkgs.join(' ')}"
==> default:      26: end
==> default:
==> default:     Compiled Resource:
==> default:     ------------------
==> default:     # Declared in /var/chef/cache/cookbooks/repose/recipes/install_debian.rb:24:in `from_file'
==> default:
==> default:     bash("install repose packages") do
==> default:       action [:run]
==> default:       retries 0
==> default:       retry_delay 2
==> default:       default_guard_interpreter :default
==> default:       command "install repose packages"
==> default:       backup 5
==> default:       returns 0
==> default:       user nil
==> default:       code "apt -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" --force-yes install repose-valve=8.10.0.1 repose-filter-bundle=8.10.0.1 repose-extensions-filter-bundle=8.10.0.1"
==> default:       interpreter "bash"
==> default:       declared_type :bash
==> default:       cookbook_name "repose"
==> default:       recipe_name "install_debian"
==> default:     end

```

After fix:
```
==> default: does not have a stable CLI interface.
==> default: Use with caution in scripts.
==> default:
==> default:               Reading package lists...
==> default:               Building dependency tree...
==> default:
==> default:               Reading state information...
==> default:               Suggested packages:
==> default:                 repose-extensions-bundle
==> default:               The following held packages will be changed:
==> default:                 repose-extensions-filter-bundle repose-filter-bundle repose-valve
==> default:               The following packages will be upgraded:
==> default:                 repose-extensions-filter-bundle repose-filter-bundle repose-valve
==> default:               3 upgraded, 0 newly installed, 0 to remove and 7 not upgraded.
==> default:
==> default: Need to get 206 MB of archives.
==> default:
==> default: After this operation, 26.1 MB of additional disk space will be used.
==> default:
==> default: Get:1 https://nexus.openrepose.org/repository/debian stable/main all repose-filter-bundle all 8.10.0.1 [69.5 MB]
==> default:               Get:2 https://nexus.openrepose.org/repository/debian stable/main all repose-extensions-filter-bundle all 8.10.0.1 [81.0 MB]
==> default:               Get:3 https://nexus.openrepose.org/repository/debian stable/main all repose-valve all 8.10.0.1 [55.8 MB]
==> default:               dpkg-preconfigure: unable to re-open stdin: No such file or directory
==> default:               Fetched 206 MB in 33s (6122 kB/s)
==> default:               (Reading database ...
(Reading database ... 60%abase ... 5%
==> default: (Reading database ... 65%
==> default: (Reading database ... 70%
==> default: (Reading database ... 75%
==> default: (Reading database ... 80%
==> default: (Reading database ... 85%
==> default: (Reading database ... 90%
==> default: (Reading database ... 95%
(Reading database ... 77842 files and directories currently installed.)
==> default:               Preparing to unpack .../repose-filter-bundle_8.10.0.1_all.deb ...
==> default:               Unpacking repose-filter-bundle (8.10.0.1) over (7.3.5.0) ...
==> default:               Preparing to unpack .../repose-extensions-filter-bundle_8.10.0.1_all.deb ...
==> default:               Unpacking repose-extensions-filter-bundle (8.10.0.1) over (7.3.5.0) ...
==> default:               Preparing to unpack .../repose-valve_8.10.0.1_all.deb ...
==> default:               Unpacking repose-valve (8.10.0.1) over (7.3.5.0) ...
==> default:               Processing triggers for ureadahead (0.100.0-19.1) ...
==> default:               Processing triggers for systemd (229-4ubuntu21.31) ...
==> default:               Setting up repose-valve (8.10.0.1) ...

```