### PR TITLE
bumping to next version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'cookbook-repose@rackspace.com'
 license 'All rights reserved'
 description 'Installs/Configures repose'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.6.4'
+version '3.6.5'
 chef_version '>= 12' if respond_to?(:chef_version)
 issues_url 'https://github.com/rackerlabs/cookbook-repose/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/rackerlabs/cookbook-repose' if respond_to?(:source_url)


### PR DESCRIPTION
Forgot to bump metadata with (previous commit)[f4decc7cb497bf7b8c763dbe291e49af451d2be2] to prepare for next release